### PR TITLE
fix: Remove no-restore flag from pack command

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -66,7 +66,6 @@ jobs:
       run: |
         dotnet pack ${{ env.PROJECT_PATH }} \
           --configuration Release \
-          --no-restore \
           --output ${{ env.PACKAGE_OUTPUT_PATH }}
 
     - name: Push to GitHub Packages


### PR DESCRIPTION
Removes the --no-restore flag from the dotnet pack command to ensure the project is properly built before packing.